### PR TITLE
Add: 카테고리뷰 기능 구현, 유닛테스트 추가

### DIFF
--- a/products/tests.py
+++ b/products/tests.py
@@ -18,6 +18,12 @@ class ProductsAppTest(TestCase):
             menu_id = 1
         )
 
+        Category.objects.create(
+            id      = 2,
+            name    = 'DO',
+            menu_id = 1
+        )
+
         SubCategory.objects.create(
             id          = 1,
             name        = 'PAK',
@@ -28,6 +34,12 @@ class ProductsAppTest(TestCase):
             id          = 2,
             name        = 'RAL',
             category_id = 1
+        )
+
+        SubCategory.objects.create(
+            id          = 3,
+            name        = 'MONS',
+            category_id = 2
         )
 
         Product.objects.create(
@@ -48,6 +60,16 @@ class ProductsAppTest(TestCase):
             description         = 'description',
             thumbnail_image_url = 'https://raw.githubusercontent.com/Djangowon/TIL/main/image/15C58535-76A3-4A64-813A-3896D4A6DEE7.jpeg',
             sub_category_id     = 2
+        )
+
+        Product.objects.create(
+            id                  = 3,
+            name                = 'DOPA',
+            price               = '9999.99',
+            brand               = 'DW',
+            description         = 'description',
+            thumbnail_image_url = 'https://raw.githubusercontent.com/Djangowon/TIL/main/image/15C58535-76A3-4A64-813A-3896D4A6DEE7.jpeg',
+            sub_category_id     = 3
         )
 
     def tearDown(self):
@@ -74,6 +96,13 @@ class ProductsAppTest(TestCase):
                 },{
                     'id':2,
                     'name':'RALO',
+                    'price':'9999.99',
+                    'brand':'DW',
+                    'description':'description',
+                    'thumbnail_image_url':'https://raw.githubusercontent.com/Djangowon/TIL/main/image/15C58535-76A3-4A64-813A-3896D4A6DEE7.jpeg'
+                },{
+                    'id':3,
+                    'name':'DOPA',
                     'price':'9999.99',
                     'brand':'DW',
                     'description':'description',
@@ -117,6 +146,34 @@ class ProductsAppTest(TestCase):
                     'description': 'description', 
                     'thumbnail_image_url': 'https://raw.githubusercontent.com/Djangowon/TIL/main/image/15C58535-76A3-4A64-813A-3896D4A6DEE7.jpeg'
                 }]
+            }
+        )
+    
+    def test_success_categories_view(self):
+        client = Client()
+        response = client.get('/products/categories?category_id=2')
+
+        self.assertEqual(response.status_code, 200)
+
+        self.assertEqual(response.json(),
+            {
+                'message':'SUCCESS',
+                'result': [{
+                    'id': 2,
+                    'name': 'DO'
+                }]
+            }
+        )
+
+    def test_error_categories_view(self):
+        client = Client()
+        response = client.get('/products/categories?category_id=kk')
+
+        self.assertEqual(response.status_code, 400)
+
+        self.assertEqual(response.json(),
+            {
+                'message':'INVALID_VALUE'
             }
         )
 
@@ -221,6 +278,7 @@ class ProductDetailTest(TestCase):
                 }
             }
         )
+
         self.assertEqual(response.status_code, 200)
 
     def test_productdetailview_get_doesnotexist(self):

--- a/products/urls.py
+++ b/products/urls.py
@@ -1,10 +1,12 @@
 from django.urls import path, include
 
 from .views      import ProductListView, ProductDetailView
+from .views      import ProductListView, CategoriesView
 
 urlpatterns=[
     path('', include([
         path('', ProductListView.as_view()),
     ])),
     path('/<int:product_id>', ProductDetailView.as_view()),
+    path('/categories', CategoriesView.as_view()),
 ]

--- a/products/views.py
+++ b/products/views.py
@@ -4,7 +4,7 @@ from django.views     import View
 from django.http      import JsonResponse
 from django.db.models import Q
 
-from .models          import Category, Product, SubCategory
+from .models          import Menu, Category, Product, SubCategory
 
 class ProductListView(View):
     def get(self, request):
@@ -56,3 +56,20 @@ class ProductDetailView(View):
 
         except Product.DoesNotExist:
             return JsonResponse({'message' : 'PRODUCT_DOESNOT_EXIST'}, status=400) 
+
+class CategoriesView(View):
+    def get(self, request):
+        try:
+            offset      = int(request.GET.get('offset', 0))
+            limit       = int(request.GET.get('limit', 6))
+            category_id = request.GET.get('category_id')
+
+            categories = [{
+                'id'      : category.id,
+                'name'    : category.name } for category in Category.objects.filter(id=category_id)[offset:offset+limit]
+            ]
+
+            return JsonResponse({'message':'SUCCESS', 'result':categories}, status=200)
+        
+        except ValueError:
+            return JsonResponse({'message':'INVALID_VALUE'}, status=400)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 프로덕트 리스트 by category 기능추가, 유닛테스트 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 메뉴 > 카테고리 > 서브카테고리 > 프로덕트 구조
- category_id 를 받아 해당 값에 해당하는 서브카테고리, 프로덕트 리스트 전달 구현
- 유닛테스트 통과

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 

<br />

## :: 기타 질문 및 특이 사항
- ProductListView 가 메뉴 안의 카테고리 안의 서브카테고리를 클릭하면 해당 서브카테고리의 프로덕트를 반환하도록 구현했는데, 서브카테고리가 참조하고 있는 카테고리만 클릭해도 카테고리의 전체 프로덕트 리스트 반환이 필요해서 카테고리 뷰를 새로 만들었습니다. 따로 만들지 않아도 되는 건지 궁금합니다!
