### PR TITLE
Add: orders_view 구현, decorator 적용, UnitTests 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3
+
+WORKDIR /usr/src/app
+
+COPY requirements.txt ./
+
+RUN pip install -r requirements.txt
+
+COPY . .
+
+EXPOSE 8000
+
+

--- a/cart/views.py
+++ b/cart/views.py
@@ -1,3 +1,0 @@
-from django.shortcuts import render
-
-# Create your views here.

--- a/orders/tests.py
+++ b/orders/tests.py
@@ -1,3 +1,208 @@
-from django.test import TestCase
+from django.test import TestCase, Client
 
-# Create your tests here.
+import json, jwt
+
+from .models import Order, OrderItem, OrderStatus
+from users.models import User
+from products.models import Product, Menu, Category, SubCategory
+from cart.models import Cart
+from unittest import mock
+from unittest.mock import patch
+from my_settings    import SECRET_KEY, ALGORITHM
+
+class OrderTest(TestCase):
+    def setUp(self):
+        
+        User.objects.create(
+            id =1,
+            name = '이지현',
+            kakao_id='kakao',
+            email='email'
+        )
+        Menu.objects.create(
+            id   = 1,
+            name = 'P'
+        )
+
+        Category.objects.create(
+            id      = 1,
+            name    = 'PA',
+            menu_id = 1
+        )
+
+        SubCategory.objects.create(
+            id          = 1,
+            name        = 'PAK',
+            category_id = 1
+        )
+
+        SubCategory.objects.create(
+            id          = 2,
+            name        = 'RAL',
+            category_id = 1
+        )
+
+        Product.objects.create(
+            id                  = 1,
+            name                = 'PAKA',
+            price               = '9999.99',
+            brand               = 'DW',
+            description         = 'description',
+            thumbnail_image_url = 'https://raw.githubusercontent.com/Djangowon/TIL/main/image/15C58535-76A3-4A64-813A-3896D4A6DEE7.jpeg',
+            sub_category_id     = 1
+        )
+
+        Product.objects.create(
+            id                  = 2,
+            name                = 'RALO',
+            price               = '9999.99',
+            brand               = 'DW',
+            description         = 'description',
+            thumbnail_image_url = 'https://raw.githubusercontent.com/Djangowon/TIL/main/image/15C58535-76A3-4A64-813A-3896D4A6DEE7.jpeg',
+            sub_category_id     = 2
+        )
+
+        OrderStatus.objects.create(
+            id = 1,
+            status = '배송중'
+        )
+        
+        OrderStatus.objects.create(
+            id = 5,
+            status = '주문취소'
+        )
+        
+        Cart.objects.create(
+            id = 1,
+            quantity = '10',
+            user_id = 1,
+            product_id = 1
+        )
+       
+        Order.objects.create(
+            id = 1,
+            user_id = 1,
+            order_status_id = 1,
+            order_number = 'a',
+            tracking_number = 'z',
+        )
+        
+        OrderItem.objects.create(
+            id = 1,
+            quantity = '10',
+            order_id = 1,
+            product_id = 1
+        )
+        
+        self.token = jwt.encode({'id':1}, SECRET_KEY, ALGORITHM)
+        
+    def tearDown(self):
+        User.objects.all().delete()
+        Product.objects.all().delete()
+        Menu.objects.all().delete()
+        Category.objects.all().delete()
+        SubCategory.objects.all().delete()
+        Order.objects.all().delete()
+        OrderStatus.objects.all().delete()
+        OrderItem.objects.all().delete()
+        Cart.objects.all().delete()
+
+    def test_orderview_post_success(self):
+        client = Client()
+        headers = {'HTTP_Authorization':self.token}
+        order = {
+            'cart_id' : 1,
+            'user_id' : 1
+        }
+        response = client.post('/orders', json.dumps(order),
+                               content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(),
+                         {'message':'Created'})
+        self.assertEqual(response.status_code, 201)
+
+    def test_orderview_post_invalid_cart_error(self):
+        client = Client()
+        headers = {'HTTP_Authorization':self.token}
+        order = {
+            'cart_id' : 3,
+            'user_id' : 1
+        }
+        response = client.post('/orders', json.dumps(order),
+                               content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(),
+                         {'message':'INVALID_CART'})
+        self.assertEqual(response.status_code, 404)
+        
+    def test_orderview_post_key_error(self):
+        client = Client()
+        headers = {'HTTP_Authorization':self.token}
+        order = {
+            'carts_id' : 3,
+            'user_id' : 1
+        }
+        response = client.post('/orders', json.dumps(order),
+                               content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(),
+                         {'message':'KEY_ERROR'})
+        self.assertEqual(response.status_code, 404)
+
+    def test_orderview_get_success(self):
+        client = Client()
+        headers = {'HTTP_Authorization':self.token}
+        response = client.get('/orders', **headers)
+        
+        self.assertEqual(response.json(),
+        { 'result' : [{
+            'order_id'     : 1,
+            'order_number' : 'a',
+            'order_status' : '배송중',
+            'products'     : [{
+                'product_id'    : 1,
+                'product_image' : 'https://raw.githubusercontent.com/Djangowon/TIL/main/image/15C58535-76A3-4A64-813A-3896D4A6DEE7.jpeg',
+                'product_name'  : 'PAKA',
+                'product_price' : '9999.99',
+                'quantity'      : 10,
+        }]}]})
+        self.assertEqual(response.status_code, 200)
+
+    def test_orderview_patch_success(self):
+        client = Client()
+        headers = {'HTTP_Authorization':self.token}
+        order = {
+            'order_id' : 1,
+        }
+        response = client.patch('/orders', json.dumps(order),
+                               content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(),
+                         {'message':'SUCCESS'})
+        self.assertEqual(response.status_code, 200)
+        
+    def test_orderview_patch_invalid_order_error(self):
+        client = Client()
+        headers = {'HTTP_Authorization':self.token}
+        order = {
+            'order_id' : 10,
+        }
+        response = client.patch('/orders', json.dumps(order),
+                               content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(),
+                         {'message':'INVALID_ORDER'})
+        self.assertEqual(response.status_code, 404)
+        
+    def test_orderview_patch_key_error(self):
+        client = Client()
+        headers = {'HTTP_Authorization':self.token}
+        order = {
+            'orer_id' : 1,
+        }
+        response = client.patch('/orders', json.dumps(order),
+                               content_type='application/json', **headers)
+        
+        self.assertEqual(response.json(),
+                         {'message':'KEY_ERROR'})
+        self.assertEqual(response.status_code, 404)

--- a/orders/urls.py
+++ b/orders/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from orders.views import OrderView
+
+urlpatterns = [
+    path('', OrderView.as_view())
+]

--- a/orders/views.py
+++ b/orders/views.py
@@ -1,3 +1,89 @@
-from django.shortcuts import render
+import json
+import uuid
 
-# Create your views here.
+from enum import Enum
+
+from django.http  import JsonResponse
+from django.views import View
+from django.db    import transaction
+
+from orders.models  import Order, OrderStatus, OrderItem
+from cart.models    import Cart
+from users.models   import User
+from core.decorator import login_required
+
+class OrderStatus(Enum):
+    WAIT_DEPOSIT     = 1
+    COMPLETE_PAYMENT = 2
+    SHIPPING         = 3
+    DELIVERED        = 4
+    CANCELLATION     = 5
+
+class OrderView(View):
+    @login_required
+    def post(self, request):
+        try:
+            data    = json.loads(request.body)
+            cart_id = data['cart_id']
+            carts   = Cart.objects.filter(id=cart_id, user=request.user)
+
+            if not carts.exists():
+                return JsonResponse({'message':'INVALID_CART'}, status=404)
+            
+            with transaction.atomic():
+                order = Order.objects.create(
+                    user            = User.objects.get(id=request.user.id),
+                    order_status_id = OrderStatus.WAIT_DEPOSIT.value, 
+                    order_number    = uuid.uuid4(),
+                    tracking_number = uuid.uuid4(),
+                    )
+                bulk_list = [OrderItem(
+                    product         = cart.product,
+                    quantity        = cart.quantity,
+                    order           = order
+                    ) for cart in carts]
+                carts.delete()
+                OrderItem.objects.bulk_create(bulk_list)
+            
+            return JsonResponse({'message':'Created'}, status=201)
+                
+        except KeyError:
+            return JsonResponse({'message':'KEY_ERROR'}, status=404)
+    
+    @login_required
+    def get(self, request):
+        orders = Order.objects.filter(user=request.user).select_related('order_status')\
+                                                   .prefetch_related('orderitem_set__product').order_by('-created_at')
+           
+        results=[{
+            'order_id'     : order.id,
+            'order_number' : order.order_number,
+            'order_status' : order.order_status.status,
+            'products'     : [{
+                'product_id'    : order_item.product.id,
+                'product_name'  : order_item.product.name,
+                'product_image' : order_item.product.thumbnail_image_url,
+                'product_price' : order_item.product.price,
+                'quantity'      : order_item.quantity,
+            } for order_item in order.orderitem_set.all()]
+        } for order in orders]
+
+        return JsonResponse({'result':results},status=200)
+
+    @login_required
+    def patch(self, request):
+        try:
+            data = json.loads(request.body)
+
+            with transaction.atomic():
+                order = Order.objects.get(id=data['order_id'])
+                order.order_status_id = OrderStatus.CANCELLATION.value
+                order.save()
+
+                return JsonResponse({'message':'SUCCESS'},status=200)
+
+        except Order.DoesNotExist:
+            return JsonResponse({'message':'INVALID_ORDER'},status=404)
+
+        except KeyError:
+            return JsonResponse({"message":"KEY_ERROR"},status=404)

--- a/teamhines/settings.py
+++ b/teamhines/settings.py
@@ -47,7 +47,7 @@ INSTALLED_APPS = [
 	'products',
 	'orders',
 	'cart',
-    'django_extensions'
+    'django_extensions',
 ]
 
 MIDDLEWARE = [

--- a/teamhines/urls.py
+++ b/teamhines/urls.py
@@ -2,6 +2,6 @@ from django.urls import path, include
 
 urlpatterns = [
     path('products', include('products.urls')),
-    path('users', include('users.urls'))
+    path('users', include('users.urls')),
+    path('orders', include('orders.urls')),
 ]
-


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- orders_view 로직 구현
- success, error 에 대한 unittest 추가

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 주문확인 페이지에 해당하는 orders_view 구현
- post : cart 에서 주문하기를 누르면 orders에 해당 유저의 id와 상품의 id들이 기록되고 결제 상태에 따라 status가 부여된다. 또한 transaction.atomic 메서드에 의해 order가 생성되면서 동시에 cart가 비워지게 된다.
- get : 생성된 order의 데이터를 토대로 결과값을 results에 담아서 보낸다.
- patch : 배송완료나 주문취소와 같은 status를 update 해주는 함수.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- Enum 함수와, ORM 최적화를 위한 select_related, prefetch_related 를 사용해봄으로써 좀 더 다양하게 view 의 로직을 구현할 수 있게 되었다. uuid 메서드로 여러가지 난수 생성 방법도 알게 되었고, transaction.atomic 에 대해서도 작동원리가 무엇인지 알게되었다.

<br />

## :: 기타 질문 및 특이 사항
- transaction exception 중에 TransactionManagementError 가 있던데, 찾아보니까 with transaction 안쪽에 try except 를 사용하면 로직이 엉키면서 발생하는 에러라고 합니다. 이러한 코딩 실수 에러에 대해서 except 하지 않아도 되나요? except 를 하는 궁극적 이유가 궁금합니다.
